### PR TITLE
(RST-6172) Changed ApplicationRecord to override ransack method to fix problem with datetime start and end ranges.

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,28 @@ class ApplicationRecord < ActiveRecord::Base
   def self.ransackable_attributes(auth_object = nil)
     authorizable_ransackable_attributes
   end
+
+  def self.ransack(*args, **kw_args)
+    if args.first.is_a?(Hash) || args.first.is_a?(ActionController::Parameters)
+      my_params = enhance_date_range_search(args.first)
+      super my_params, **kw_args
+    else
+      super *args, **kw_args
+    end
+  end
+
+  def self.enhance_date_range_search(params)
+    my_params = params.dup
+
+    my_params.keys.select do |key|
+      next unless key.ends_with?('_lteq') && my_params.key?(key.sub('_lteq', '_gteq')) && is_date_time_type?(key.sub('_lteq', ''))
+
+      my_params[key] = my_params[key] + ' 23:59:59'
+    end
+    my_params
+  end
+
+  def self.is_date_time_type?(key)
+    columns_hash[key].type == :datetime
+  end
 end


### PR DESCRIPTION

### Jira link (if applicable)

RST-6172

### Change description ###

(RST-6172) Changed ApplicationRecord to override ransack method to fix problem with datetime start and end ranges.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
